### PR TITLE
Directly specify docker image for CirceCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,8 @@ orbs:
 
 jobs:
   lint:
-    executor: 
-      name: python/default
-      tag: 3.6.9
+    docker:
+      - image: circleci/python:3.6.9
     steps:
       - checkout
       - python/install-packages:


### PR DESCRIPTION
Specifying the python version makes the orb-version longer anyway